### PR TITLE
docs: add terminal background and foreground values to palette

### DIFF
--- a/docs/palette.md
+++ b/docs/palette.md
@@ -382,6 +382,8 @@ Each accent color has four semantic layers for different use cases:
 
 | Element         | Light Theme | Dark Theme | Usage                    |
 | :-------------- | :---------- | :--------- | :----------------------- |
+| Background      | paper       | black      | Terminal background      |
+| Foreground      | base-800    | base-200   | Terminal default text    |
 | Cursor          | base-850    | base-200   | Terminal cursor          |
 | Cursor Text     | paper       | black      | Text under cursor        |
 | Selection       | blue-100    | blue-900   | Selected text background |


### PR DESCRIPTION
Document the fundamental terminal color values that were missing from the Terminal Window Colors table. These values define the base background and text colors for terminal implementations of the Flexoki theme.