### PR TITLE
feat: add comprehensive theme customization system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Theme Configuration System**: Comprehensive customization options allowing users to override any aspect of the theme
+  - `theme` option to force specific theme ("auto", "dark", "light") overriding `vim.o.background`
+  - `palette_override` table for direct hex color value overrides of base Flexoki colors
+  - `dark_override` function for customizing dark theme semantic color mapping
+  - `light_override` function for customizing light theme semantic color mapping
+  - `highlight_override` function for direct highlight group customizations
+- **Type Definitions**: Complete LuaLS annotations for all configuration options
+  - `flexoki.Config` type with all optional configuration fields
+  - `flexoki.ThemeOverride` function type for theme customization
+  - `flexoki.HighlightOverride` function type for highlight customization
+- **Layered Override System**: Clear precedence order (palette → theme → highlights) for predictable customization
+- **Documentation**: Extensive customization examples and color reference in README.md
 - Documentation for color palette reference (`docs/palette.md`)
 - Documentation for syntax highlighting research and decisions (`docs/syntax-highlighting-research.md`)
 - Extended palette with subtle background colors (level 4) for improved visual hierarchy
 
-### Fixed
-
-- Aligned syntax highlighting colors with documented guidelines in `palette.md`:
-  - Keywords now use magenta (was green)
-  - Strings now use green (was cyan)
-  - Functions now use blue (was orange)
-  - Numbers now use orange (was purple)
-  - Types now use cyan (was green)
-  - Built-in constants now use orange (was magenta)
-
 ### Changed
 
+- **Configuration Architecture**: Refactored internal structure to support comprehensive theme customization
+  - Enhanced `setup()` function to accept all configuration options
+  - Modified `palette.get()` to apply palette overrides and theme-specific overrides
+  - Updated `load()` function to process highlight overrides in correct precedence order
+  - Reorganized color mapping functions to accept override parameters
 - **BREAKING**: Renamed types for better clarity:
   - `flexoki.HighlightGroups` → `flexoki.HighlightGroup` (singular for consistency)
   - `flexoki.Colors` → `flexoki.PaletteColors` (more descriptive naming)
+- **Documentation Structure**: Reorganized README.md with comprehensive customization section
+  - Added practical configuration examples with both hex values and semantic color references
+  - Documented override precedence and available color options
+  - Reordered theme switching section for better flow
 - Improved semantic consistency across highlight groups:
   - Enhanced diff highlighting with color-matched backgrounds
   - Unified search highlighting appearance between normal and current search
@@ -44,6 +55,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved highlight group type to `groups/base.lua` for shared access
   - Updated type comments to match authoritative `palette.md` documentation
   - Fixed typo in Config field documentation (highlight vs hightlight)
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Aligned syntax highlighting colors with documented guidelines in `palette.md`:
+  - Keywords now use magenta (was green)
+  - Strings now use green (was cyan)
+  - Functions now use blue (was orange)
+  - Numbers now use orange (was purple)
+  - Types now use cyan (was green)
+  - Built-in constants now use orange (was magenta)
+
+### Security
 
 ## [0.1.0] - 2025-01-23
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ lazy.nvim
 ### Load the color scheme
 
 ```lua
--- Basic setup and load color scheme
+-- Setup default and load color scheme
 require("flexoki").setup()
 vim.cmd.colorscheme("flexoki")
 ```
 
 ### Switch between dark and light themes
 
-The color scheme will automatically switch between dark and light themes based on the value of background (:help background).
+By default, the color scheme will automatically switch between dark and light themes based on the value of background (:help background).
 
 ```lua
 -- Switch to dark theme
@@ -49,6 +49,82 @@ vim.o.background = "dark"
 -- Switch to light theme
 vim.o.background = "light"
 ```
+
+## Customization
+
+Flexoki provides a comprehensive override system allowing you to customize every aspect of the theme. **All configuration options are optional** - use only what you need:
+
+```lua
+require("flexoki").setup({
+  -- Force theme (overrides vim.o.background)
+  -- "auto" (default) | "dark" | "light"
+  theme = "auto",
+
+  -- Override base palette colors
+  palette_override = {
+    red600 = "#ff0000",  -- Direct hex values
+    base950 = "#0a0a0a", -- Darker background
+  },
+
+  -- Customize dark theme semantic colors
+  dark_override = function(colors)
+    return {
+      bg = "#000000",      -- Direct hex value
+      tx = colors.base200, -- Or semantic color reference
+      blue = "#00aaff",    -- Custom blue accent
+    }
+  end,
+
+  -- Customize light theme semantic colors
+  light_override = function(colors)
+    return {
+      bg = colors.paper, -- Semantic reference
+      tx = "#1a1a1a",    -- Direct hex value
+    }
+  end,
+
+  -- Override specific highlight groups
+  highlight_override = function(colors)
+    return {
+      Comment = { fg = "#9966cc", italic = true },    -- Direct hex
+      Function = { fg = colors.yellow, bold = true }, -- Semantic reference
+      ["@keyword"] = { fg = "#ff6b9d" },              -- Direct hex
+    }
+  end,
+})
+```
+
+### Override Order
+
+Overrides are applied in this order:
+
+1. **Palette Override** → Modifies base Flexoki colors
+2. **Theme Override** → Adjusts semantic color mapping
+3. **Highlight Override** → Customizes final highlight groups
+
+### Available Colors
+
+**Palette Colors** (for palette overrides):
+
+- Base: `black`, `base950` through `base50`, `paper`
+- Colors: `red950` through `red50` (and similar for all accent colors)
+
+**Semantic Colors** (for theme overrides):
+
+- `bg`, `bg2` - Background colors
+- `ui`, `ui2`, `ui3` - UI element colors
+- `tx`, `tx2`, `tx3` - Text colors
+- `red`, `orange`, `yellow`, `green`, `cyan`, `blue`, `purple`, `magenta` - Accent colors
+- Each accent has variants: `red2`, `red3`, `red4` for different intensities
+
+See [docs/palette.md](docs/palette.md) for the complete color reference.
+
+### Color Values
+
+All override functions accept either:
+
+- **Hex strings**: `"#ff0000"`, `"#1a1a1a"`
+- **Semantic references**: `colors.red600`, `colors.base950`
 
 ## Integrations
 

--- a/lua/flexoki/groups/base.lua
+++ b/lua/flexoki/groups/base.lua
@@ -1,5 +1,3 @@
----@alias flexoki.HighlightGroup table<string, vim.api.keyset.highlight>
-
 local M = {}
 
 ---@param colors flexoki.ThemeColors

--- a/lua/flexoki/init.lua
+++ b/lua/flexoki/init.lua
@@ -3,23 +3,30 @@
 -- URL: https://stephango.com/flexoki
 -- License: MIT
 
+---@alias flexoki.HighlightGroup table<string, vim.api.keyset.highlight>
+---@alias flexoki.ThemeOverride fun(colors: flexoki.PaletteColors): flexoki.ThemeColors
+---@alias flexoki.HighlightOverride fun(colors: flexoki.ThemeColors): flexoki.HighlightGroup
+
 ---@class flexoki.Config
----@field groups string[] List of highlight group names to enable
+---@field theme? "auto" | flexoki.Theme Theme applied by colorscheme
+---@field groups? string[] List of highlight groups to enable
+---@field palette_override? table<string, string> Palette color overrides
+---@field dark_override? flexoki.ThemeOverride Dark theme overrides
+---@field light_override? flexoki.ThemeOverride Light theme overrides
+---@field highlight_override? flexoki.HighlightOverride Highlight overrides
 
 ---@class flexoki.Module
----@field colors flexoki.ThemeColors The current theme's color palette
----@field config flexoki.Config The current configuration
-local M = {
-    ---@diagnostic disable-next-line: missing-fields
-    colors = {},
-    config = {
-        groups = {},
-    },
-}
+---@field colors flexoki.ThemeColors Current theme colors
+---@field config flexoki.Config Current configuration
+local M = {}
 
 ---Load the Flexoki color scheme based on vim.o.background
 ---@return nil
 function M.load()
+    if not M.config then
+        M.setup()
+    end
+
     if vim.fn.exists("syntax_on") then
         vim.cmd("syntax reset")
     end
@@ -27,13 +34,20 @@ function M.load()
     vim.o.termguicolors = true
     vim.g.colors_name = "flexoki"
 
-    M.colors = require("flexoki.palette").get(vim.o.background)
+    local theme = vim.o.background --[[@as flexoki.Theme]]
+    if M.config.theme ~= "auto" then
+        theme = M.config.theme --[[@as flexoki.Theme]]
+    end
+
+    M.colors = require("flexoki.palette").get(theme, M.config)
     local highlights = require("flexoki.groups.base").get(M.colors)
 
     for _, group in ipairs(M.config.groups) do
         local group_highlights = require("flexoki.groups." .. group).get(M.colors)
         highlights = vim.tbl_extend("force", highlights, group_highlights)
     end
+
+    highlights = vim.tbl_extend("force", highlights, M.config.highlight_override(M.colors))
 
     for name, val in pairs(highlights) do
         vim.api.nvim_set_hl(0, name, val)
@@ -44,7 +58,17 @@ end
 ---@param opts? flexoki.Config Optional user configuration
 ---@return nil
 function M.setup(opts)
-    M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+    --stylua: ignore
+    local defaultfn = function() return {} end
+    local config = {
+        theme = "auto",
+        groups = {},
+        palette_override = {},
+        dark_override = defaultfn,
+        light_override = defaultfn,
+        highlight_override = defaultfn,
+    }
+    M.config = vim.tbl_deep_extend("force", config, opts or {})
 end
 
 return M

--- a/lua/flexoki/palette.lua
+++ b/lua/flexoki/palette.lua
@@ -167,7 +167,7 @@
 local M = {}
 
 ---@return flexoki.PaletteColors
-function M.all_colors()
+function M.all()
     return {
         -- Base colors
         black = "#100F0F",
@@ -310,7 +310,7 @@ end
 
 ---@param colors flexoki.PaletteColors
 ---@return flexoki.ThemeColors
-function M.dark_colors(colors)
+function M.dark(colors)
     return {
         bg = colors.black,
         bg2 = colors.base950,
@@ -359,7 +359,7 @@ end
 
 ---@param colors flexoki.PaletteColors
 ---@return flexoki.ThemeColors
-function M.light_colors(colors)
+function M.light(colors)
     return {
         bg = colors.paper,
         bg2 = colors.base50,
@@ -407,14 +407,16 @@ function M.light_colors(colors)
 end
 
 ---@param theme flexoki.Theme
+---@param config flexoki.Config
 ---@return flexoki.ThemeColors
-function M.get(theme)
-    local colors = M.all_colors()
+function M.get(theme, config)
+    local colors = M.all()
+    colors = vim.tbl_extend("force", colors, config.palette_override)
 
     if theme == "dark" then
-        return M.dark_colors(colors)
+        return vim.tbl_extend("force", M.dark(colors), config.dark_override(colors))
     else
-        return M.light_colors(colors)
+        return vim.tbl_extend("force", M.light(colors), config.light_override(colors))
     end
 end
 


### PR DESCRIPTION
- Add palette_override, dark_override, light_override, and highlight_override options
- Add theme option to force specific theme overriding vim.o.background
- Add complete LuaLS type annotations for all configuration options
- Implement layered override system with clear precedence order
- Update documentation with customization examples